### PR TITLE
Add branching choice system with narrative consequences

### DIFF
--- a/src/__tests__/choiceHandler.test.ts
+++ b/src/__tests__/choiceHandler.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { presentChoice, resolveChoice } from '../engine/handlers/choiceHandler'
+import { choices } from '../data/choices'
+import { parseCommand } from '../engine/commandParser'
+import { checkMidRunAchievements } from '../engine/achievements'
+import type { Item } from '../types/item'
+import type { Companion } from '../types/companion'
+
+afterEach(() => vi.restoreAllMocks())
+
+const makeItem = (overrides?: Partial<Item>): Item => ({
+  id: 'healing-potion',
+  name: 'Healing Potion',
+  description: 'A red potion.',
+  type: 'potion',
+  value: 10,
+  ...overrides,
+})
+
+const makeCompanion = (overrides?: Partial<Companion>): Companion => ({
+  id: 'trapped-elf',
+  name: 'Elanor',
+  hp: 18,
+  maxHp: 18,
+  ac: 14,
+  attackBonus: 4,
+  damage: '1d6+2',
+  roomComments: {},
+  genericComments: ['A comment.'],
+  deathMessage: 'Elanor has fallen.',
+  ...overrides,
+})
+
+// ── presentChoice ──────────────────────────────────────────
+
+describe('presentChoice', () => {
+  it('returns narrative text and option descriptions', () => {
+    const choice = choices['wounded-goblin']!
+    const result = presentChoice(choice)
+
+    expect(result.logs.length).toBeGreaterThanOrEqual(4) // system + narrative + 3 options + info prompt
+    expect(result.logs[0]!.text).toContain('The Wounded Goblin')
+    expect(result.logs[0]!.type).toBe('system')
+    expect(result.logs[1]!.type).toBe('narrative')
+    // Options presented as info logs
+    const infoLogs = result.logs.filter(l => l.type === 'info')
+    expect(infoLogs.length).toBeGreaterThanOrEqual(3) // 3 options + prompt
+  })
+
+  it('returns activeChoice with all options', () => {
+    const choice = choices['wounded-goblin']!
+    const result = presentChoice(choice)
+
+    expect(result.activeChoice.choiceId).toBe('wounded-goblin')
+    expect(result.activeChoice.options).toHaveLength(3)
+    expect(result.activeChoice.options.map(o => o.id)).toEqual(['mercy', 'kill', 'ignore'])
+  })
+
+  it('generates dynamic description for bridge sacrifice with companion name', () => {
+    const choice = choices['bridge-sacrifice']!
+    const result = presentChoice(choice, 'Elanor')
+
+    const narrativeLog = result.logs.find(l => l.type === 'narrative')
+    expect(narrativeLog!.text).toContain('Elanor')
+  })
+
+  it('uses static description for non-bridge choices', () => {
+    const choice = choices['oris-knowledge']!
+    const result = presentChoice(choice)
+
+    const narrativeLog = result.logs.find(l => l.type === 'narrative')
+    expect(narrativeLog!.text).toContain('Ori')
+  })
+})
+
+// ── Wounded Goblin ─────────────────────────────────────────
+
+describe('resolveChoice — wounded goblin', () => {
+  const ctx = (inventory: Item[]) => ({
+    inventory,
+    companions: [],
+  })
+
+  it('mercy with potion: returns XP, potion consumption, enemy removal', () => {
+    const result = resolveChoice('wounded-goblin', 'mercy', ctx([makeItem()]))
+
+    expect(result.optionId).toBe('mercy')
+    expect(result.xp).toBe(15)
+    expect(result.consumeHealingPotion).toBe(true)
+    expect(result.removeEnemies).toEqual({
+      roomId: 'orc-lair',
+      enemyId: 'orc-warrior',
+      count: 1,
+    })
+    expect(result.consequenceFlags?.['goblin-mercy']).toBe(true)
+    expect(result.logs.some(l => l.text.includes('Grishnak'))).toBe(true)
+  })
+
+  it('mercy without potion: fails gracefully', () => {
+    const result = resolveChoice('wounded-goblin', 'mercy', ctx([]))
+
+    expect(result.optionId).toBe('') // empty = failed resolution
+    expect(result.xp).toBeUndefined()
+    expect(result.consumeHealingPotion).toBeUndefined()
+    expect(result.logs.some(l => l.type === 'error')).toBe(true)
+  })
+
+  it('kill: returns XP and gold, no enemy removal', () => {
+    const result = resolveChoice('wounded-goblin', 'kill', ctx([]))
+
+    expect(result.optionId).toBe('kill')
+    expect(result.xp).toBe(10)
+    expect(result.gold).toBe(5)
+    expect(result.removeEnemies).toBeUndefined()
+    expect(result.logs.some(l => l.text.includes('swift strike'))).toBe(true)
+  })
+
+  it('ignore: returns narrative only, no rewards', () => {
+    const result = resolveChoice('wounded-goblin', 'ignore', ctx([]))
+
+    expect(result.optionId).toBe('ignore')
+    expect(result.xp).toBeUndefined()
+    expect(result.gold).toBeUndefined()
+    expect(result.removeEnemies).toBeUndefined()
+    expect(result.logs.some(l => l.text.includes('step over'))).toBe(true)
+  })
+})
+
+// ── Ori's Knowledge ────────────────────────────────────────
+
+describe("resolveChoice — Ori's Knowledge", () => {
+  const ctx = { inventory: [] as Item[], companions: [] as Companion[] }
+
+  it('accept: returns attack bonus + maxHp reduction', () => {
+    const result = resolveChoice('oris-knowledge', 'accept', ctx)
+
+    expect(result.optionId).toBe('accept')
+    expect(result.attackBonus).toBe(2)
+    expect(result.maxHpChange).toBe(-6)
+    expect(result.consequenceFlags?.['oris-knowledge-accepted']).toBe(true)
+    expect(result.logs.some(l => l.text.includes('battle-lore'))).toBe(true)
+  })
+
+  it('refuse: returns AC bonus, no HP loss', () => {
+    const result = resolveChoice('oris-knowledge', 'refuse', ctx)
+
+    expect(result.optionId).toBe('refuse')
+    expect(result.acBonus).toBe(1)
+    expect(result.maxHpChange).toBeUndefined()
+    expect(result.attackBonus).toBeUndefined()
+    expect(result.consequenceFlags?.['oris-blessing']).toBe(true)
+    expect(result.logs.some(l => l.text.includes('wiser than we were'))).toBe(true)
+  })
+})
+
+// ── Sealed Vault ───────────────────────────────────────────
+
+describe('resolveChoice — sealed vault', () => {
+  const ctx = { inventory: [] as Item[], companions: [] as Companion[] }
+
+  it('open: returns miruvor item + enemy spawn', () => {
+    const result = resolveChoice('sealed-vault', 'open', ctx)
+
+    expect(result.optionId).toBe('open')
+    expect(result.itemIds).toEqual(['miruvor'])
+    expect(result.spawnEnemies).toEqual({
+      roomId: 'chamber-of-records',
+      enemyId: 'orc-warrior',
+      count: 2,
+    })
+    expect(result.consequenceFlags?.['vault-opened']).toBe(true)
+  })
+
+  it('leave: returns narrative only, no items or spawns', () => {
+    const result = resolveChoice('sealed-vault', 'leave', ctx)
+
+    expect(result.optionId).toBe('leave')
+    expect(result.itemIds).toBeUndefined()
+    expect(result.spawnEnemies).toBeUndefined()
+    expect(result.logs.some(l => l.text.includes('doors are best left closed'))).toBe(true)
+  })
+})
+
+// ── Bridge Sacrifice ───────────────────────────────────────
+
+describe('resolveChoice — bridge sacrifice', () => {
+  it('sacrifice with companion: returns companion death + boss damage + skip turn', () => {
+    // Mock dice for deterministic damage
+    vi.spyOn(Math, 'random').mockReturnValue(0.5) // middling roll
+    const companion = makeCompanion()
+    const result = resolveChoice('bridge-sacrifice', 'sacrifice', {
+      inventory: [],
+      companions: [companion],
+    })
+
+    expect(result.optionId).toBe('sacrifice')
+    expect(result.sacrificeCompanion).toBe(true)
+    expect(result.bossDamage).toBeGreaterThan(0)
+    expect(result.skipEnemyTurn).toBe(true)
+    expect(result.consequenceFlags?.['companion-sacrificed']).toBe(true)
+    expect(result.logs.some(l => l.text.includes('Elanor'))).toBe(true)
+  })
+
+  it('sacrifice without companion: fails', () => {
+    const result = resolveChoice('bridge-sacrifice', 'sacrifice', {
+      inventory: [],
+      companions: [],
+    })
+
+    expect(result.optionId).toBe('') // failed
+    expect(result.sacrificeCompanion).toBeUndefined()
+    expect(result.logs.some(l => l.type === 'error')).toBe(true)
+  })
+
+  it('sacrifice with dead companion: fails', () => {
+    const deadCompanion = makeCompanion({ hp: 0 })
+    const result = resolveChoice('bridge-sacrifice', 'sacrifice', {
+      inventory: [],
+      companions: [deadCompanion],
+    })
+
+    expect(result.optionId).toBe('') // failed
+  })
+
+  it('refuse with companion: returns narrative, no death', () => {
+    const companion = makeCompanion()
+    const result = resolveChoice('bridge-sacrifice', 'refuse', {
+      inventory: [],
+      companions: [companion],
+    })
+
+    expect(result.optionId).toBe('refuse')
+    expect(result.sacrificeCompanion).toBeUndefined()
+    expect(result.bossDamage).toBeUndefined()
+    expect(result.logs.some(l => l.text.includes('together we stand'))).toBe(true)
+  })
+
+  it('refuse without companion: still returns narrative', () => {
+    const result = resolveChoice('bridge-sacrifice', 'refuse', {
+      inventory: [],
+      companions: [],
+    })
+
+    expect(result.optionId).toBe('refuse')
+    expect(result.logs.some(l => l.text.includes('together'))).toBe(true)
+  })
+})
+
+// ── Unknown choice ─────────────────────────────────────────
+
+describe('resolveChoice — unknown', () => {
+  it('returns error for unknown choice id', () => {
+    const result = resolveChoice('nonexistent', 'whatever', {
+      inventory: [],
+      companions: [],
+    })
+
+    expect(result.logs.some(l => l.type === 'error')).toBe(true)
+  })
+})
+
+// ── Choice data validation ─────────────────────────────────
+
+describe('choices data', () => {
+  it('all choices have valid structure', () => {
+    for (const [id, choice] of Object.entries(choices)) {
+      expect(choice.id).toBe(id)
+      expect(choice.name).toBeTruthy()
+      expect(choice.options.length).toBeGreaterThanOrEqual(2)
+      expect(choice.roomId).toBeTruthy()
+
+      for (const opt of choice.options) {
+        expect(opt.id).toBeTruthy()
+        expect(opt.label).toBeTruthy()
+        expect(opt.description).toBeTruthy()
+      }
+    }
+  })
+
+  it('wounded-goblin has 3 options: mercy, kill, ignore', () => {
+    const choice = choices['wounded-goblin']!
+    expect(choice.options.map(o => o.id)).toEqual(['mercy', 'kill', 'ignore'])
+  })
+
+  it('oris-knowledge has 2 options: accept, refuse', () => {
+    const choice = choices['oris-knowledge']!
+    expect(choice.options.map(o => o.id)).toEqual(['accept', 'refuse'])
+  })
+
+  it('sealed-vault has 2 options: open, leave', () => {
+    const choice = choices['sealed-vault']!
+    expect(choice.options.map(o => o.id)).toEqual(['open', 'leave'])
+  })
+
+  it('bridge-sacrifice has 2 options: sacrifice, refuse', () => {
+    const choice = choices['bridge-sacrifice']!
+    expect(choice.options.map(o => o.id)).toEqual(['sacrifice', 'refuse'])
+  })
+})
+
+// ── Command parser integration ─────────────────────────────
+
+describe('choose command parsing', () => {
+  it('parses "choose mercy" correctly', () => {
+    const cmd = parseCommand('choose mercy')
+    expect(cmd.type).toBe('choose')
+    expect(cmd.target).toBe('mercy')
+  })
+
+  it('parses "choose accept" correctly', () => {
+    const cmd = parseCommand('choose accept')
+    expect(cmd.type).toBe('choose')
+    expect(cmd.target).toBe('accept')
+  })
+
+  it('parses "decide refuse" correctly', () => {
+    const cmd = parseCommand('decide refuse')
+    expect(cmd.type).toBe('choose')
+    expect(cmd.target).toBe('refuse')
+  })
+
+  it('parses "choose" without target', () => {
+    const cmd = parseCommand('choose')
+    expect(cmd.type).toBe('choose')
+    expect(cmd.target).toBeUndefined()
+  })
+})
+
+// ── Achievement integration ────────────────────────────────
+
+describe('mercy achievement', () => {
+  const baseStats = {
+    roomsExplored: 5,
+    totalRooms: 18,
+    enemiesKilled: 3,
+    damageDealt: 50,
+    damageTaken: 20,
+    itemsFound: 2,
+    potionsUsed: 1,
+    puzzlesSolved: 0,
+    secretsFound: 0,
+    sneakSuccesses: 0,
+    fleeAttempts: 0,
+    startTime: Date.now(),
+    playerClass: 'ranger' as const,
+    difficulty: 'normal' as const,
+    balrogSlain: false,
+    itemsCrafted: 0,
+    choicesMadeCount: 0,
+    mercyShown: false,
+  }
+
+  it('unlocks mercy achievement when mercyShown is true', () => {
+    const stats = { ...baseStats, mercyShown: true, choicesMadeCount: 1 }
+    const earned = checkMidRunAchievements(stats, [])
+    expect(earned).toContain('mercy-of-the-valar')
+  })
+
+  it('does not unlock mercy achievement when mercyShown is false', () => {
+    const earned = checkMidRunAchievements(baseStats, [])
+    expect(earned).not.toContain('mercy-of-the-valar')
+  })
+})

--- a/src/components/ActionBar.vue
+++ b/src/components/ActionBar.vue
@@ -12,6 +12,7 @@ const combatStore = useCombatStore()
 const player = computed(() => playerStore.player)
 const inCombat = computed(() => combatStore.inCombat)
 const atForge = computed(() => gameStore.currentRoomId === 'abandoned-forge' && !inCombat.value)
+const activeChoice = computed(() => gameStore.activeChoice)
 
 interface ActionItem {
   id: string
@@ -83,8 +84,18 @@ function itemActionLabel(item: { id: string; name: string; type: string }) {
 
 <template>
   <div v-if="player && gameStore.phase === 'playing'" class="flex flex-wrap gap-1.5 md:gap-2 px-1 shrink-0">
+    <!-- Active Choice -->
+    <template v-if="activeChoice">
+      <button
+        v-for="opt in activeChoice.options"
+        :key="opt.id"
+        @click="cmd(`choose ${opt.id}`)"
+        class="px-2.5 py-1.5 md:px-2 md:py-1 text-[11px] md:text-xs rounded border border-purple-500/60 bg-purple-500/15 text-purple-400 hover:bg-purple-500/30 cursor-pointer transition-colors"
+      >{{ opt.label }}</button>
+    </template>
+
     <!-- Combat Mode -->
-    <template v-if="inCombat">
+    <template v-else-if="inCombat">
       <!-- Attack buttons -->
       <button
         v-for="enemy in combatStore.livingEnemies"

--- a/src/data/choices.ts
+++ b/src/data/choices.ts
@@ -1,0 +1,96 @@
+import type { Choice } from '../types/choice'
+
+export const choices: Record<string, Choice> = {
+  'wounded-goblin': {
+    id: 'wounded-goblin',
+    name: 'The Wounded Goblin',
+    description:
+      'Among the fallen goblins, one still lives. It drags itself toward you, whimpering, one leg bent at a terrible angle. It raises a clawed hand — not to strike, but to plead. "No kill! No kill! Grishnak knows things... Grishnak can help tall-one. Give Grishnak medicine, and Grishnak tells big-orcs to leave tall-one alone. Grishnak promises!"',
+    options: [
+      {
+        id: 'mercy',
+        label: 'Show Mercy',
+        description:
+          'Give Grishnak a healing potion. He will warn the orcs in the lair ahead to stand down. (Costs 1 Healing Potion)',
+      },
+      {
+        id: 'kill',
+        label: 'End Its Suffering',
+        description:
+          'A quick death is more than most goblins would grant you. Put the creature out of its misery.',
+      },
+      {
+        id: 'ignore',
+        label: 'Walk Away',
+        description:
+          'This is not your concern. Leave the goblin to its fate and press on.',
+      },
+    ],
+    roomId: 'goblin-tunnels',
+  },
+
+  'oris-knowledge': {
+    id: 'oris-knowledge',
+    name: "Ori's Forbidden Knowledge",
+    description:
+      'The shade of Ori flickers and grows brighter. "There is... one more thing I can offer you, living one. The knowledge of the deep places — battle-lore the dwarves learned fighting nameless things in the dark. It will make you deadly. But such knowledge was never meant for mortal minds. It will consume part of you — your vitality, your very life-force. The choice is yours."',
+    options: [
+      {
+        id: 'accept',
+        label: 'Accept the Knowledge',
+        description:
+          'Gain Ori\'s battle-lore: +2 attack bonus permanently. But the forbidden knowledge burns away part of your life force — lose 6 maximum HP.',
+      },
+      {
+        id: 'refuse',
+        label: 'Decline Respectfully',
+        description:
+          'Refuse the dark knowledge. Ori respects your wisdom and grants a blessing of protection instead: +1 AC permanently.',
+      },
+    ],
+    roomId: 'chamber-of-records',
+  },
+
+  'sealed-vault': {
+    id: 'sealed-vault',
+    name: 'The Sealed Vault',
+    description:
+      'Behind the irregular stonework in the mining shaft, your fingers find a hidden seam — a sealed vault door, dwarven-made, with runes of warning etched around its frame. Through a crack you glimpse something glinting within: a crystal flask of Miruvor, the cordial of Imladris. But the warning runes are clear: "SEALED BY ORDER OF DURIN. WHAT SLEEPS BEYOND, LET NONE WAKE." Opening this vault may disturb things best left undisturbed.',
+    options: [
+      {
+        id: 'open',
+        label: 'Break the Seal',
+        description:
+          'Force the vault open and claim the Miruvor. But the noise and released energy may alert enemies deeper in the mines.',
+      },
+      {
+        id: 'leave',
+        label: 'Heed the Warning',
+        description:
+          'The dwarves sealed this for a reason. Leave it be and trust their wisdom.',
+      },
+    ],
+    roomId: 'mining-shaft',
+  },
+
+  'bridge-sacrifice': {
+    id: 'bridge-sacrifice',
+    name: 'The Bridge Sacrifice',
+    description: '', // Set dynamically based on companion name
+    options: [
+      {
+        id: 'sacrifice',
+        label: 'Accept Their Sacrifice',
+        description:
+          'Your companion will charge the Balrog, buying you precious time — but they will not survive.',
+      },
+      {
+        id: 'refuse',
+        label: 'Refuse — Fight Together',
+        description:
+          'You will not let another die for you. Stand together against the darkness.',
+      },
+    ],
+    roomId: 'bridge-of-khazad-dum',
+  },
+}

--- a/src/engine/achievements.ts
+++ b/src/engine/achievements.ts
@@ -25,6 +25,8 @@ export interface RunStats {
   difficulty: DifficultyLevel
   balrogSlain: boolean
   itemsCrafted: number
+  choicesMadeCount: number
+  mercyShown: boolean
 }
 
 export const achievements: Record<string, Achievement> = {
@@ -94,6 +96,12 @@ export const achievements: Record<string, Achievement> = {
     description: 'Craft an item at the Abandoned Forge.',
     icon: 'F',
   },
+  'mercy-of-the-valar': {
+    id: 'mercy-of-the-valar',
+    name: 'Mercy of the Valar',
+    description: 'Show mercy to the wounded goblin.',
+    icon: 'V',
+  },
 }
 
 const TOTAL_PUZZLES = 5 // speak-friend, forge-levers, gargoyle-riddle, stair-descent, records-ward
@@ -128,6 +136,10 @@ export function checkMidRunAchievements(stats: RunStats, foundItems: string[]): 
 
   if (stats.itemsCrafted >= 1) {
     earned.push('forge-master')
+  }
+
+  if (stats.mercyShown) {
+    earned.push('mercy-of-the-valar')
   }
 
   return earned

--- a/src/engine/commandParser.ts
+++ b/src/engine/commandParser.ts
@@ -105,6 +105,11 @@ export function parseCommand(input: string): ParsedCommand {
     return { type: 'search', target: rest || undefined, raw }
   }
 
+  // Choose (branching choices)
+  if (verb === 'choose' || verb === 'decide') {
+    return { type: 'choose', target: rest || undefined, raw }
+  }
+
   // Craft
   if (verb === 'craft' || verb === 'forge') {
     return { type: 'craft', target: rest || undefined, raw }

--- a/src/engine/handlers/choiceHandler.ts
+++ b/src/engine/handlers/choiceHandler.ts
@@ -1,0 +1,260 @@
+import type { Choice, ActiveChoice } from '../../types/choice'
+import type { Companion } from '../../types/companion'
+import type { Item } from '../../types/item'
+import { entry, type HandlerResult } from './types'
+import { rollDice } from '../dice'
+
+export interface ChoicePresentResult extends HandlerResult {
+  activeChoice: ActiveChoice
+}
+
+/** Present a choice to the player with narrative and option descriptions. */
+export function presentChoice(choice: Choice, companionName?: string): ChoicePresentResult {
+  const description =
+    choice.id === 'bridge-sacrifice' && companionName
+      ? `${companionName} steps forward, eyes blazing with desperate courage. "You cannot defeat this thing alone — not like this. Let me buy you time. I will charge the Balrog and give you an opening. I... I will not survive. But you might. Let me do this."`
+      : choice.description
+
+  const logs = [
+    entry(`--- ${choice.name} ---`, 'system'),
+    entry(description, 'narrative'),
+  ]
+
+  for (const opt of choice.options) {
+    logs.push(entry(`${opt.label}: ${opt.description}`, 'info'))
+  }
+
+  logs.push(entry('(Type "choose <option>" to decide.)', 'info'))
+
+  return {
+    logs,
+    activeChoice: {
+      choiceId: choice.id,
+      options: choice.options,
+    },
+  }
+}
+
+// ── Resolution results ─────────────────────────────────────
+
+export interface ChoiceResolutionResult extends HandlerResult {
+  choiceId: string
+  optionId: string
+  /** XP to award */
+  xp?: number
+  /** Gold to award */
+  gold?: number
+  /** Item IDs to drop on the ground */
+  itemIds?: string[]
+  /** Remove a healing potion from inventory */
+  consumeHealingPotion?: boolean
+  /** Permanent max HP change (negative = loss) */
+  maxHpChange?: number
+  /** Permanent attack bonus to grant */
+  attackBonus?: number
+  /** Permanent AC bonus to grant */
+  acBonus?: number
+  /** Enemies to remove from a room: { roomId, enemyId, count } */
+  removeEnemies?: { roomId: string; enemyId: string; count: number }
+  /** Enemies to spawn in a room */
+  spawnEnemies?: { roomId: string; enemyId: string; count: number }
+  /** Kill the first companion (sacrifice) */
+  sacrificeCompanion?: boolean
+  /** Damage to deal to the boss */
+  bossDamage?: number
+  /** Skip enemy turn this round */
+  skipEnemyTurn?: boolean
+  /** Flag to record in choiceConsequences */
+  consequenceFlags?: Record<string, boolean>
+}
+
+/** Resolve the player's choice. Returns descriptors of side-effects for the store to apply. */
+export function resolveChoice(
+  choiceId: string,
+  optionId: string,
+  context: {
+    inventory: Item[]
+    companions: Companion[]
+  },
+): ChoiceResolutionResult {
+  switch (choiceId) {
+    case 'wounded-goblin': return resolveWoundedGoblin(optionId, context.inventory)
+    case 'oris-knowledge': return resolveOrisKnowledge(optionId)
+    case 'sealed-vault':   return resolveSealedVault(optionId)
+    case 'bridge-sacrifice': return resolveBridgeSacrifice(optionId, context.companions)
+    default:
+      return {
+        choiceId,
+        optionId,
+        logs: [entry(`Unknown choice "${choiceId}".`, 'error')],
+      }
+  }
+}
+
+// ── Individual choice resolvers ────────────────────────────
+
+function resolveWoundedGoblin(optionId: string, inventory: Item[]): ChoiceResolutionResult {
+  const choiceId = 'wounded-goblin'
+
+  if (optionId === 'mercy') {
+    const hasPotion = inventory.some(i => i.id === 'healing-potion')
+    if (!hasPotion) {
+      return {
+        choiceId,
+        optionId: '',
+        logs: [entry('You reach for a healing potion, but you don\'t have one. The goblin whimpers.', 'error')],
+      }
+    }
+
+    return {
+      choiceId,
+      optionId,
+      consumeHealingPotion: true,
+      xp: 15,
+      removeEnemies: { roomId: 'orc-lair', enemyId: 'orc-warrior', count: 1 },
+      consequenceFlags: { 'goblin-mercy': true },
+      logs: [
+        entry('You kneel and pour the healing potion over the goblin\'s shattered leg. Grishnak\'s eyes widen with disbelief — then something like gratitude.', 'narrative'),
+        entry('"Tall-one is... kind. Grishnak not forget. Grishnak tells big-orcs: leave this one alone. Grishnak promises on his teeth!"', 'narrative'),
+        entry('The goblin scuttles away into the darkness. You feel a strange warmth — perhaps mercy has its own rewards.', 'narrative'),
+        entry('(+15 XP. The orcs ahead have been warned — some will stand down.)', 'loot'),
+      ],
+    }
+  }
+
+  if (optionId === 'kill') {
+    return {
+      choiceId,
+      optionId,
+      xp: 10,
+      gold: 5,
+      consequenceFlags: {},
+      logs: [
+        entry('You end the goblin\'s suffering with a swift strike. It is a mercy of a different kind.', 'narrative'),
+        entry('Among its rags you find a few coins.', 'narrative'),
+        entry('(+10 XP, +5 gold)', 'loot'),
+      ],
+    }
+  }
+
+  // ignore
+  return {
+    choiceId,
+    optionId: 'ignore',
+    consequenceFlags: {},
+    logs: [
+      entry('You step over the wounded goblin and press on. It watches you go with glittering, unreadable eyes.', 'narrative'),
+    ],
+  }
+}
+
+function resolveOrisKnowledge(optionId: string): ChoiceResolutionResult {
+  const choiceId = 'oris-knowledge'
+
+  if (optionId === 'accept') {
+    return {
+      choiceId,
+      optionId,
+      attackBonus: 2,
+      maxHpChange: -6,
+      consequenceFlags: { 'oris-knowledge-accepted': true },
+      logs: [
+        entry('Ori\'s shade reaches out and touches your forehead. A searing flood of battle-lore pours into your mind — centuries of dwarven combat against nameless terrors in the deep.', 'narrative'),
+        entry('You see through Ori\'s eyes: the last stand at Balin\'s tomb, the desperate fighting retreats, the terrible things that crawled up from below. You learn to fight as the dwarves fought — savagely, precisely, without mercy.', 'narrative'),
+        entry('But the knowledge burns. You feel something vital drain away, like warmth leaving your body on a winter night.', 'narrative'),
+        entry('(+2 permanent attack bonus. -6 maximum HP. The knowledge is a blade with no hilt.)', 'loot'),
+      ],
+    }
+  }
+
+  // refuse
+  return {
+    choiceId,
+    optionId: 'refuse',
+    acBonus: 1,
+    consequenceFlags: { 'oris-blessing': true },
+    logs: [
+      entry('"No," you say quietly. "I will face what comes with my own strength."', 'narrative'),
+      entry('Ori\'s shade regards you with something like respect — or perhaps relief. "Then you are wiser than we were. We reached for power in the dark, and the dark reached back."', 'narrative'),
+      entry('The ghost raises a translucent hand in blessing. A faint warmth settles over you like a cloak.', 'narrative'),
+      entry('(+1 permanent AC. Ori\'s blessing guards you.)', 'loot'),
+    ],
+  }
+}
+
+function resolveSealedVault(optionId: string): ChoiceResolutionResult {
+  const choiceId = 'sealed-vault'
+
+  if (optionId === 'open') {
+    return {
+      choiceId,
+      optionId,
+      itemIds: ['miruvor'],
+      spawnEnemies: { roomId: 'chamber-of-records', enemyId: 'orc-warrior', count: 2 },
+      consequenceFlags: { 'vault-opened': true },
+      logs: [
+        entry('You put your shoulder to the ancient seal and heave. Stone grinds against stone, and the vault door swings inward with a groan that echoes through the mines.', 'narrative'),
+        entry('Inside, untouched for an age, rests a crystal flask of Miruvor — the cordial of Imladris, still potent after all these years.', 'narrative'),
+        entry('But the sound carries. Far off, you hear guttural voices raised in alarm. Something has heard you. The Chamber of Records may no longer be safe.', 'narrative'),
+        entry('(Found Miruvor! But orc warriors have been alerted to the Chamber of Records.)', 'loot'),
+      ],
+    }
+  }
+
+  // leave
+  return {
+    choiceId,
+    optionId: 'leave',
+    consequenceFlags: {},
+    logs: [
+      entry('You trace the warning runes with your fingertips and step back. The dwarves knew what they were doing when they sealed this place. Some doors are best left closed.', 'narrative'),
+      entry('"Not all treasure is worth the finding," you murmur — words Gandalf might have spoken.', 'narrative'),
+    ],
+  }
+}
+
+function resolveBridgeSacrifice(optionId: string, companions: Companion[]): ChoiceResolutionResult {
+  const choiceId = 'bridge-sacrifice'
+  const livingCompanion = companions.find(c => c.hp > 0)
+
+  if (optionId === 'sacrifice') {
+    if (!livingCompanion) {
+      return {
+        choiceId,
+        optionId: '',
+        logs: [entry('You have no companion to make this sacrifice.', 'error')],
+      }
+    }
+
+    const dmg = rollDice('3d10+0')
+
+    return {
+      choiceId,
+      optionId,
+      sacrificeCompanion: true,
+      bossDamage: dmg.total,
+      skipEnemyTurn: true,
+      consequenceFlags: { 'companion-sacrificed': true },
+      logs: [
+        entry(`${livingCompanion.name} charges the Balrog with a desperate cry!`, 'combat'),
+        entry(`Blade flashing, ${livingCompanion.name} strikes the Balrog again and again, driving it back from the bridge. Fire licks at their cloak, their hair, their skin — but they do not falter.`, 'narrative'),
+        entry(`The Balrog takes ${dmg.total} damage from ${livingCompanion.name}'s assault!`, 'combat'),
+        entry(`With a final, terrible blow, the Balrog swats ${livingCompanion.name} into the abyss. They fall without a sound, swallowed by the darkness below. They are gone.`, 'narrative'),
+        entry(`But they bought you time. The Balrog staggers, momentarily stunned by the ferocity of the attack. You have one free round to act.`, 'info'),
+      ],
+    }
+  }
+
+  // refuse
+  const companionName = livingCompanion?.name ?? 'Your companion'
+  return {
+    choiceId,
+    optionId: 'refuse',
+    consequenceFlags: {},
+    logs: [
+      entry(`"No," you say firmly. "We fight together, or not at all."`, 'narrative'),
+      entry(`${companionName}'s eyes shine with unshed tears. "Then together we stand, against fire and shadow. To whatever end."`, 'narrative'),
+      entry('The battle continues.', 'info'),
+    ],
+  }
+}

--- a/src/engine/saveLoad.ts
+++ b/src/engine/saveLoad.ts
@@ -55,6 +55,11 @@ export function serialize(): SaveData {
     recruitableNPCsOffered: setToArray(gameStore.recruitableNPCsOffered),
     seenEncounters: setToArray(gameStore.seenEncounters),
     activeEncounter: gameStore.activeEncounter ? JSON.parse(JSON.stringify(gameStore.activeEncounter)) : null,
+    activeChoice: gameStore.activeChoice ? JSON.parse(JSON.stringify(gameStore.activeChoice)) : null,
+    choicesMade: { ...gameStore.choicesMade },
+    choiceConsequences: { ...gameStore.choiceConsequences },
+    removedEnemies: { ...gameStore.removedEnemies },
+    addedEnemies: JSON.parse(JSON.stringify(gameStore.addedEnemies)),
 
     // combatStore
     inCombat: combatStore.inCombat,
@@ -63,6 +68,7 @@ export function serialize(): SaveData {
     darkCombat: combatStore.darkCombat,
     bossPhase: combatStore.bossPhase,
     bossFallBack: combatStore.bossFallBack,
+    skipNextEnemyTurn: combatStore.skipNextEnemyTurn,
 
     // statsStore
     statsStore: {
@@ -82,6 +88,8 @@ export function serialize(): SaveData {
       difficulty: statsStore.difficulty,
       balrogSlain: statsStore.balrogSlain,
       foundItems: [...statsStore.foundItems],
+      choicesMadeCount: statsStore.choicesMadeCount,
+      mercyShown: statsStore.mercyShown,
     },
   }
 }
@@ -120,6 +128,11 @@ export function deserialize(data: SaveData): void {
   gameStore.recruitableNPCsOffered = arrayToSet(data.recruitableNPCsOffered)
   gameStore.seenEncounters = arrayToSet(data.seenEncounters ?? [])
   gameStore.activeEncounter = data.activeEncounter ?? null
+  gameStore.activeChoice = data.activeChoice ?? null
+  gameStore.choicesMade = data.choicesMade ?? {}
+  gameStore.choiceConsequences = data.choiceConsequences ?? {}
+  gameStore.removedEnemies = data.removedEnemies ?? {}
+  gameStore.addedEnemies = data.addedEnemies ?? {}
 
   // combatStore
   combatStore.inCombat = data.inCombat
@@ -128,6 +141,7 @@ export function deserialize(data: SaveData): void {
   combatStore.darkCombat = data.darkCombat
   combatStore.bossPhase = data.bossPhase as BossPhase
   combatStore.bossFallBack = data.bossFallBack
+  combatStore.skipNextEnemyTurn = data.skipNextEnemyTurn ?? false
 
   // statsStore
   const ss = data.statsStore
@@ -147,6 +161,8 @@ export function deserialize(data: SaveData): void {
   statsStore.difficulty = ss.difficulty
   statsStore.balrogSlain = ss.balrogSlain
   statsStore.foundItems = ss.foundItems
+  statsStore.choicesMadeCount = ss.choicesMadeCount ?? 0
+  statsStore.mercyShown = ss.mercyShown ?? false
 
   // Re-splice recruited companions out of roomNPCs
   for (const comp of data.companions) {

--- a/src/stores/combatStore.ts
+++ b/src/stores/combatStore.ts
@@ -24,6 +24,7 @@ export const useCombatStore = defineStore('combat', () => {
   const bossPhase = ref<BossPhase>(0)
   const bossFallBack = ref(false)
   const lastCritical = ref(false)
+  const skipNextEnemyTurn = ref(false)
 
   const livingEnemies = computed(() => combatEnemies.value.filter(e => e.hp > 0))
   const combatOver = computed(() => inCombat.value && livingEnemies.value.length === 0)
@@ -36,6 +37,7 @@ export const useCombatStore = defineStore('combat', () => {
     darkCombat.value = isDark
     bossPhase.value = 0
     bossFallBack.value = false
+    skipNextEnemyTurn.value = false
 
     const multipliers = getDifficultyMultipliers()
 
@@ -89,6 +91,15 @@ export const useCombatStore = defineStore('combat', () => {
     if (transition) {
       logs.push(...transition.logs)
       bossPhase.value = transition.newPhase
+
+      // Bridge sacrifice choice: offered at phase 2 if companion alive and choice not made
+      if (transition.newPhase === 2) {
+        const livingCompanion = companions.value.find(c => c.hp > 0)
+        if (livingCompanion) {
+          // Signal to gameStore to present the choice (via event on logs)
+          logs.push({ text: `__BRIDGE_SACRIFICE__`, type: 'system', timestamp: 0 })
+        }
+      }
     }
 
     // Environmental fire damage in phases 2+
@@ -371,6 +382,12 @@ export const useCombatStore = defineStore('combat', () => {
   }
 
   function doEnemyTurns(): GameLogEntry[] {
+    // Skip enemy turn if triggered by companion sacrifice
+    if (skipNextEnemyTurn.value) {
+      skipNextEnemyTurn.value = false
+      return [{ text: 'The enemies are momentarily stunned — you have a free round!', type: 'combat', timestamp: Date.now() }]
+    }
+
     const playerStore = usePlayerStore()
     if (!playerStore.player) return []
 
@@ -563,6 +580,7 @@ export const useCombatStore = defineStore('combat', () => {
     combatEnemies.value = []
     bossPhase.value = 0
     bossFallBack.value = false
+    skipNextEnemyTurn.value = false
 
     // Clear combat-only status effects (keep blessed)
     const playerStore = usePlayerStore()
@@ -583,6 +601,7 @@ export const useCombatStore = defineStore('combat', () => {
     bossFallBack,
     isBossFight,
     lastCritical,
+    skipNextEnemyTurn,
     startCombat,
     doPlayerAttack,
     doPlayerCast,

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -37,6 +37,9 @@ import { useCombatStore } from './combatStore'
 import { useStatsStore } from './statsStore'
 import { listRecipes, tryCraft, craftedItems } from '../engine/crafting'
 import { applyStatusEffect } from '../engine/statusEffects'
+import type { ActiveChoice } from '../types/choice'
+import { choices } from '../data/choices'
+import { presentChoice, resolveChoice, type ChoiceResolutionResult } from '../engine/handlers/choiceHandler'
 
 export type GamePhase = 'title' | 'character-select' | 'playing' | 'game-over' | 'victory'
 
@@ -62,6 +65,13 @@ export const useGameStore = defineStore('game', () => {
   const recruitableNPCsOffered = ref<Set<string>>(new Set())
   const seenEncounters = ref<Set<string>>(new Set())
   const activeEncounter = ref<ActiveEncounter | null>(null)
+  const activeChoice = ref<ActiveChoice | null>(null)
+  const choicesMade = ref<Record<string, string>>({})
+  const choiceConsequences = ref<Record<string, boolean>>({})
+  /** Enemies removed from rooms by choice consequences: `roomId:enemyId` → count removed */
+  const removedEnemies = ref<Record<string, number>>({})
+  /** Enemies spawned into rooms by choice consequences */
+  const addedEnemies = ref<Record<string, { enemyId: string; count: number }[]>>({})
 
   const currentRoom = computed(() => getRoom(currentRoomId.value))
 
@@ -152,6 +162,11 @@ export const useGameStore = defineStore('game', () => {
     recruitableNPCsOffered.value = new Set()
     seenEncounters.value = new Set()
     activeEncounter.value = null
+    activeChoice.value = null
+    choicesMade.value = {}
+    choiceConsequences.value = {}
+    removedEnemies.value = {}
+    addedEnemies.value = {}
     applyLightState({ hasLight: false, turnsRemaining: 0, permanent: false })
 
     roomItems.value = {}
@@ -184,6 +199,7 @@ export const useGameStore = defineStore('game', () => {
     if (currentRoomId.value !== roomId) {
       previousRoomId.value = currentRoomId.value
       activeEncounter.value = null // clear encounter on room change
+      activeChoice.value = null   // clear choice on room change
     }
     currentRoomId.value = roomId
     const wasNew = !visitedRooms.value.has(roomId)
@@ -260,6 +276,24 @@ export const useGameStore = defineStore('game', () => {
       }
     }
 
+    // Room-based choices (trigger once after room is cleared)
+    if (roomId === 'goblin-tunnels' && clearedRooms.value.has(roomId) && !choicesMade.value['wounded-goblin']) {
+      const choice = choices['wounded-goblin']
+      if (choice) {
+        const result = presentChoice(choice)
+        pushLogs(result.logs)
+        activeChoice.value = result.activeChoice
+      }
+    }
+    if (roomId === 'mining-shaft' && revealedExits.value.has('mining-shaft-west') && !choicesMade.value['sealed-vault']) {
+      const choice = choices['sealed-vault']
+      if (choice) {
+        const result = presentChoice(choice)
+        pushLogs(result.logs)
+        activeChoice.value = result.activeChoice
+      }
+    }
+
     // Trap (pure handler)
     if (room.trap && !disarmedTraps.value.has(roomId)) {
       const playerStore = usePlayerStore()
@@ -277,10 +311,34 @@ export const useGameStore = defineStore('game', () => {
       }
     }
 
-    // Combat
-    if (room.enemies && room.enemies.length > 0 && !clearedRooms.value.has(roomId)) {
+    // Combat (including choice-spawned enemies)
+    const hasOriginalEnemies = room.enemies && room.enemies.length > 0 && !clearedRooms.value.has(roomId)
+    const spawnedEnemies = addedEnemies.value[roomId]
+    if (hasOriginalEnemies || spawnedEnemies) {
       const combatStore = useCombatStore()
-      pushLogs(combatStore.startCombat(room.enemies, dark))
+      // Build effective enemy list
+      let effectiveEnemies = hasOriginalEnemies ? [...room.enemies!] : []
+      // Remove enemies reduced by choices
+      effectiveEnemies = effectiveEnemies.map(re => {
+        const key = `${roomId}:${re.enemyId}`
+        const removed = removedEnemies.value[key] ?? 0
+        if (removed > 0) {
+          const newCount = Math.max(0, re.count - removed)
+          return { ...re, count: newCount }
+        }
+        return re
+      }).filter(re => re.count > 0)
+      // Add choice-spawned enemies
+      if (spawnedEnemies) {
+        for (const se of spawnedEnemies) {
+          effectiveEnemies.push({ enemyId: se.enemyId, count: se.count })
+        }
+        // Spawned enemies are one-time — clear after triggering
+        delete addedEnemies.value[roomId]
+      }
+      if (effectiveEnemies.length > 0) {
+        pushLogs(combatStore.startCombat(effectiveEnemies, dark))
+      }
     }
 
     // Mid-run achievements
@@ -340,6 +398,7 @@ export const useGameStore = defineStore('game', () => {
       case 'say':     handleSay(cmd); break
       case 'solve':   handleSolve(cmd); break
       case 'craft':   handleCraft(cmd); break
+      case 'choose':  handleChoose(cmd); break
       case 'inventory': handleInventory(); break
       case 'stats':   handleStats(); break
       case 'help':    handleHelp(); break
@@ -543,7 +602,9 @@ export const useGameStore = defineStore('game', () => {
     const combatStore = useCombatStore()
     if (!combatStore.inCombat) { log('There is nothing to attack here.', 'error'); return }
 
-    pushLogs(combatStore.doPlayerAttack(cmd.target))
+    const combatLogs = combatStore.doPlayerAttack(cmd.target)
+    pushLogs(combatLogs.filter(l => l.text !== '__BRIDGE_SACRIFICE__'))
+    checkBridgeSacrificeSignal(combatLogs)
     markRoomCleared()
     checkDeath()
   }
@@ -568,9 +629,26 @@ export const useGameStore = defineStore('game', () => {
     const combatStore = useCombatStore()
     if (!combatStore.inCombat) { log('You can only cast combat spells during battle.', 'error'); return }
 
-    pushLogs(combatStore.doPlayerCast(cmd.target))
+    const combatLogs = combatStore.doPlayerCast(cmd.target)
+    pushLogs(combatLogs.filter(l => l.text !== '__BRIDGE_SACRIFICE__'))
+    checkBridgeSacrificeSignal(combatLogs)
     markRoomCleared()
     checkDeath()
+  }
+
+  /** Check if combat logs contain the bridge sacrifice trigger signal. */
+  function checkBridgeSacrificeSignal(logs: GameLogEntry[]) {
+    if (!logs.some(l => l.text === '__BRIDGE_SACRIFICE__')) return
+    if (choicesMade.value['bridge-sacrifice']) return
+    const livingCompanion = companions.value.find(c => c.hp > 0)
+    if (!livingCompanion) return
+
+    const choice = choices['bridge-sacrifice']
+    if (choice) {
+      const result = presentChoice(choice, livingCompanion.name)
+      pushLogs(result.logs)
+      activeChoice.value = result.activeChoice
+    }
   }
 
   // ── Take ───────────────────────────────────────────────────
@@ -936,6 +1014,17 @@ export const useGameStore = defineStore('game', () => {
       }
     }
 
+    // Ori's forbidden knowledge choice — triggers on second talk after interaction
+    if (npc.id === 'ghost-of-ori' && interactedNPCs.value.has(npc.id) && !choicesMade.value['oris-knowledge']) {
+      const choice = choices['oris-knowledge']
+      if (choice) {
+        const choiceResult = presentChoice(choice)
+        pushLogs(choiceResult.logs)
+        activeChoice.value = choiceResult.activeChoice
+      }
+      return
+    }
+
     // After quest reward given (interacted), offer recruitment if applicable
     if (npc.recruitableCompanionId && interactedNPCs.value.has(npc.id) && !recruitableNPCsOffered.value.has(npc.id)) {
       if (!companions.value.some(c => c.id === npc.recruitableCompanionId)) {
@@ -1202,6 +1291,145 @@ export const useGameStore = defineStore('game', () => {
     }
   }
 
+  // ── Choices ──────────────────────────────────────────────
+  function handleChoose(cmd: ParsedCommand) {
+    if (!activeChoice.value) {
+      log('There is no choice to make right now.', 'error')
+      return
+    }
+
+    const optionId = cmd.target?.toLowerCase()
+    if (!optionId) {
+      log('Choose what? Type "choose <option>".', 'error')
+      return
+    }
+
+    // Match option by id or label
+    const option = activeChoice.value.options.find(
+      o => o.id === optionId || o.label.toLowerCase().includes(optionId),
+    )
+    if (!option) {
+      const validOptions = activeChoice.value.options.map(o => o.id).join(', ')
+      log(`Unknown option "${optionId}". Valid options: ${validOptions}`, 'error')
+      return
+    }
+
+    const playerStore = usePlayerStore()
+    if (!playerStore.player) return
+
+    const result = resolveChoice(activeChoice.value.choiceId, option.id, {
+      inventory: playerStore.inventory,
+      companions: companions.value,
+    })
+
+    // If no optionId in result, resolution failed (e.g., missing potion)
+    if (!result.optionId) {
+      pushLogs(result.logs)
+      return
+    }
+
+    pushLogs(result.logs)
+    applyChoiceConsequences(result, playerStore)
+
+    // Record the choice
+    choicesMade.value[result.choiceId] = result.optionId
+    activeChoice.value = null
+
+    // Track stats
+    useStatsStore().recordChoiceMade(result.choiceId, result.optionId)
+
+    checkDeath()
+    useStatsStore().checkMidRunAchievements()
+  }
+
+  function applyChoiceConsequences(result: ChoiceResolutionResult, playerStore: ReturnType<typeof usePlayerStore>) {
+    if (!playerStore.player) return
+
+    if (result.xp) pushLogs(playerStore.addXp(result.xp))
+    if (result.gold) playerStore.player.gold += result.gold
+
+    if (result.consumeHealingPotion) {
+      playerStore.removeItem('healing-potion')
+    }
+
+    if (result.itemIds) {
+      for (const itemId of result.itemIds) {
+        dropItemToGround(itemId)
+      }
+    }
+
+    if (result.maxHpChange) {
+      playerStore.player.maxHp += result.maxHpChange
+      playerStore.player.hp = Math.min(playerStore.player.hp, playerStore.player.maxHp)
+      if (result.maxHpChange < 0) {
+        log(`Your maximum HP is reduced by ${Math.abs(result.maxHpChange)}.`, 'combat')
+      }
+    }
+
+    if (result.attackBonus) {
+      // Add as a long-duration status effect
+      playerStore.player.statusEffects.push({
+        id: 'blessed' as import('../types/statusEffect').StatusEffectId,
+        name: "Ori's Battle-Lore",
+        description: 'Forbidden knowledge of dwarven combat burns in your mind.',
+        duration: 9999,
+        attackBonus: result.attackBonus,
+      })
+    }
+
+    if (result.acBonus) {
+      playerStore.player.statusEffects.push({
+        id: 'blessed' as import('../types/statusEffect').StatusEffectId,
+        name: "Ori's Blessing",
+        description: 'The shade of Ori guards your steps.',
+        duration: 9999,
+        acBonus: result.acBonus,
+      })
+    }
+
+    if (result.removeEnemies) {
+      const { roomId, enemyId, count } = result.removeEnemies
+      const key = `${roomId}:${enemyId}`
+      removedEnemies.value[key] = (removedEnemies.value[key] ?? 0) + count
+    }
+
+    if (result.spawnEnemies) {
+      const { roomId, enemyId, count } = result.spawnEnemies
+      if (!addedEnemies.value[roomId]) addedEnemies.value[roomId] = []
+      addedEnemies.value[roomId]!.push({ enemyId, count })
+      // Also un-clear the room so combat triggers on next entry
+      clearedRooms.value.delete(roomId)
+    }
+
+    if (result.sacrificeCompanion) {
+      const living = companions.value.find(c => c.hp > 0)
+      if (living) {
+        living.hp = 0
+        log(`${living.name} has fallen.`, 'combat')
+      }
+    }
+
+    if (result.bossDamage) {
+      const combatStore = useCombatStore()
+      const balrog = combatStore.livingEnemies.find(e => e.id === 'balrog')
+      if (balrog) {
+        balrog.hp -= result.bossDamage
+        if (balrog.hp <= 0) balrog.hp = 0
+      }
+    }
+
+    if (result.skipEnemyTurn) {
+      const combatStore = useCombatStore()
+      combatStore.skipNextEnemyTurn = true
+    }
+
+    if (result.consequenceFlags) {
+      for (const [key, val] of Object.entries(result.consequenceFlags)) {
+        choiceConsequences.value[key] = val
+      }
+    }
+  }
+
   // ── Save / Load ──────────────────────────────────────────
   function handleSave() {
     import('../engine/saveLoad').then(({ saveGame }) => {
@@ -1308,6 +1536,11 @@ export const useGameStore = defineStore('game', () => {
     recruitableNPCsOffered,
     seenEncounters,
     activeEncounter,
+    activeChoice,
+    choicesMade,
+    choiceConsequences,
+    removedEnemies,
+    addedEnemies,
     getDifficultyMultipliers,
     initGame,
     handleCommand,

--- a/src/stores/statsStore.ts
+++ b/src/stores/statsStore.ts
@@ -26,6 +26,8 @@ export const useStatsStore = defineStore('stats', () => {
   const balrogSlain = ref(false)
   const foundItems = ref<string[]>([])
   const itemsCrafted = ref(0)
+  const choicesMadeCount = ref(0)
+  const mercyShown = ref(false)
 
   // ── Persistent achievements ──────────────────────────────
   const unlockedAchievements = ref<Set<string>>(loadAchievements())
@@ -73,6 +75,8 @@ export const useStatsStore = defineStore('stats', () => {
     balrogSlain.value = false
     foundItems.value = []
     itemsCrafted.value = 0
+    choicesMadeCount.value = 0
+    mercyShown.value = false
     newlyUnlocked.value = []
   }
 
@@ -92,6 +96,12 @@ export const useStatsStore = defineStore('stats', () => {
   function recordFleeAttempt() { fleeAttempts.value++ }
   function recordBalrogSlain() { balrogSlain.value = true }
   function recordItemCrafted() { itemsCrafted.value++ }
+  function recordChoiceMade(choiceId: string, optionId: string) {
+    choicesMadeCount.value++
+    if (choiceId === 'wounded-goblin' && optionId === 'mercy') {
+      mercyShown.value = true
+    }
+  }
 
   function dismissToast(id: string) {
     toastQueue.value = toastQueue.value.filter(t => t.id !== id)
@@ -115,6 +125,8 @@ export const useStatsStore = defineStore('stats', () => {
       difficulty: difficulty.value,
       balrogSlain: balrogSlain.value,
       itemsCrafted: itemsCrafted.value,
+      choicesMadeCount: choicesMadeCount.value,
+      mercyShown: mercyShown.value,
     }
   }
 
@@ -193,6 +205,9 @@ export const useStatsStore = defineStore('stats', () => {
     recordFleeAttempt,
     recordBalrogSlain,
     recordItemCrafted,
+    recordChoiceMade,
+    choicesMadeCount,
+    mercyShown,
     checkEndOfRun,
   }
 })

--- a/src/types/choice.ts
+++ b/src/types/choice.ts
@@ -1,0 +1,19 @@
+export interface ChoiceOption {
+  id: string
+  label: string
+  description: string
+}
+
+export interface Choice {
+  id: string
+  name: string
+  description: string
+  options: ChoiceOption[]
+  roomId: string
+}
+
+/** Runtime state when a choice is active (mirrors ActiveEncounter pattern). */
+export interface ActiveChoice {
+  choiceId: string
+  options: ChoiceOption[]
+}

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -19,6 +19,7 @@ export type CommandType =
   | 'search'
   | 'destroy'
   | 'craft'
+  | 'choose'
   | 'inventory'
   | 'stats'
   | 'help'

--- a/src/types/save.ts
+++ b/src/types/save.ts
@@ -8,8 +8,9 @@ import type { DifficultyLevel } from './difficulty'
 import type { PlayerClass } from './character'
 import type { BossPhase } from '../engine/handlers/bossHandler'
 import type { ActiveEncounter } from './encounter'
+import type { ActiveChoice } from './choice'
 
-export const SAVE_VERSION = 1
+export const SAVE_VERSION = 2
 export const SAVE_KEY = 'moria-save'
 
 export interface SaveData {
@@ -44,6 +45,11 @@ export interface SaveData {
   recruitableNPCsOffered: string[]
   seenEncounters: string[]
   activeEncounter: ActiveEncounter | null
+  activeChoice: ActiveChoice | null
+  choicesMade: Record<string, string>
+  choiceConsequences: Record<string, boolean>
+  removedEnemies: Record<string, number>
+  addedEnemies: Record<string, { enemyId: string; count: number }[]>
 
   // combatStore
   inCombat: boolean
@@ -52,6 +58,7 @@ export interface SaveData {
   darkCombat: boolean
   bossPhase: BossPhase
   bossFallBack: boolean
+  skipNextEnemyTurn: boolean
 
   // statsStore (per-run only; achievements self-persist)
   statsStore: {
@@ -71,5 +78,7 @@ export interface SaveData {
     difficulty: DifficultyLevel
     balrogSlain: boolean
     foundItems: string[]
+    choicesMadeCount: number
+    mercyShown: boolean
   }
 }


### PR DESCRIPTION
## Summary
Implements a comprehensive branching choice system that allows players to make meaningful decisions at key story moments, with consequences that affect gameplay (XP, items, stats, enemy spawning/removal, companion sacrifice).

## Key Changes

- **New choice handler** (`src/engine/handlers/choiceHandler.ts`): Core logic for presenting choices to players and resolving their consequences
  - `presentChoice()`: Displays choice narrative and options with dynamic companion name support
  - `resolveChoice()`: Processes player decisions and returns structured consequence descriptors (XP, items, stat changes, enemy modifications)
  - Individual resolvers for four major choices: wounded goblin, Ori's knowledge, sealed vault, bridge sacrifice

- **Choice data** (`src/data/choices.ts`): Defines four branching choices with narrative text and options
  - Wounded Goblin: mercy (costs potion, removes enemies), kill (grants gold), or ignore
  - Ori's Knowledge: accept forbidden knowledge (+2 attack, -6 max HP) or refuse (+1 AC)
  - Sealed Vault: open (gets Miruvor, spawns enemies) or leave
  - Bridge Sacrifice: companion sacrifices self (deals boss damage, skips enemy turn) or refuse

- **Game store integration** (`src/stores/gameStore.ts`):
  - Added choice state tracking: `activeChoice`, `choicesMade`, `choiceConsequences`, `removedEnemies`, `addedEnemies`
  - `handleChoose()` command handler with option matching and consequence application
  - Choice triggers integrated into room entry logic (wounded goblin after clearing goblin-tunnels, sealed vault after revealing mining-shaft-west)
  - Bridge sacrifice choice triggered during combat via signal mechanism
  - Enemy list filtering to apply choice-based removals and spawns

- **Combat store enhancement** (`src/stores/combatStore.ts`):
  - Added `skipNextEnemyTurn` flag to support bridge sacrifice consequence
  - Signal mechanism (`__BRIDGE_SACRIFICE__` log marker) to trigger choice presentation during boss combat

- **Type definitions** (`src/types/choice.ts`): New `Choice`, `ChoiceOption`, and `ActiveChoice` interfaces

- **Stats tracking** (`src/stores/statsStore.ts`):
  - Added `choicesMadeCount` and `mercyShown` counters
  - `recordChoiceMade()` method to track choices
  - Achievement unlock for "Mercy of the Valar" when mercy is shown

- **Achievement system** (`src/engine/achievements.ts`):
  - New "Mercy of the Valar" achievement for showing mercy to the wounded goblin

- **Save/load support** (`src/engine/saveLoad.ts`, `src/types/save.ts`):
  - Serialization of all choice-related state
  - Save version bumped to 2

- **Command parser** (`src/engine/commandParser.ts`): Added "choose" and "decide" command parsing

- **UI** (`src/components/ActionBar.vue`): Choice options displayed in action bar when active

- **Comprehensive test suite** (`src/__tests__/choiceHandler.test.ts`): 363 lines of tests covering all choice paths, consequence application, and edge cases

## Notable Implementation Details

- Choices are presented once per playthrough and tracked in `choicesMade` to prevent re-triggering
- Enemy modifications use a key-based system (`roomId:enemyId`) to track removals and spawns separately
- Bridge sacrifice integrates with combat via a special log signal to trigger at the right narrative moment
- Consequence application is centralized in `applyChoiceConsequences()` for consistency
- Status effects (attack bonus, AC bonus) are applied as long-duration effects (9999 turns)
- Failed resolutions (e.g., mercy without potion) return empty `optionId` and error logs without applying consequences

https://claude.ai/code/session_01RRxUQxc5yz4nsY2K3GbCDP