### PR TITLE
Auto-persist game state to localStorage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import { useGameStore } from './stores/gameStore'
+import { hasSaveGame, loadGame } from './engine/saveLoad'
 import TitleScreen from './views/TitleScreen.vue'
 import CharacterSelect from './views/CharacterSelect.vue'
 import GameScreen from './views/GameScreen.vue'
 
 const gameStore = useGameStore()
+
+onMounted(() => {
+  if (hasSaveGame()) {
+    loadGame()
+  }
+})
 </script>
 
 <template>

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -21,6 +21,7 @@ import { playSound } from '../engine/audio'
 import { checkRecruitment, rollCompanionComment } from '../engine/handlers/companionHandler'
 import { difficulty, currentRoomId, roomItems, companions, getDifficultyMultipliers, dropItemToGround } from './gameContext'
 import { SAVE_KEY } from '../types/save'
+import { saveGame } from '../engine/saveLoad'
 import { encounters as encounterPool } from '../data/encounters'
 import {
   shouldTriggerEncounter,
@@ -432,6 +433,11 @@ export const useGameStore = defineStore('game', () => {
       })
       pushLogs(result.logs)
       applyLightState(result.newState)
+    }
+
+    // Auto-save after state-changing commands
+    if (!['help', 'stats', 'inventory', 'map', 'load'].includes(cmd.type)) {
+      saveGame()
     }
   }
 


### PR DESCRIPTION
## Summary
- Auto-save game state to localStorage after every state-changing command in `handleCommand()`, reusing the existing `saveGame()` infrastructure
- Auto-load saved state on app mount in `App.vue`, so page refreshes resume gameplay immediately without going through the title screen
- Info-only commands (help, stats, inventory, map) and `load` are skipped to avoid unnecessary writes

## Test plan
- [ ] Start a new game, move a few rooms, refresh the page — should resume in the same room with full state
- [ ] Verify inventory, combat state, companions, and light state persist across refresh
- [ ] Verify dying still clears the save (existing `checkDeath` calls `localStorage.removeItem`)
- [ ] Verify new players with no save still see the title screen
- [ ] Verify manual `save`/`load` commands still work as before

https://claude.ai/code/session_01N7CAcgo6CpKHV3adM2HRqe